### PR TITLE
Simplify isOdd check to avoid bitwise double not operation

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,5 +16,5 @@ module.exports = function isOdd(i) {
   if (Number(i) !== Math.floor(i)) {
     throw new RangeError('is-odd expects an integer.');
   }
-  return !!(~~i & 1);
+  return !!(i & 1);
 };


### PR DESCRIPTION
This works as `&` operator already casts an argument to 32-bit integer