### PR TITLE
Simplify the codebase

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,14 +7,8 @@
 
 'use strict';
 
-var isNumber = require('is-number');
+var isEven = require('is-even');
 
 module.exports = function isOdd(i) {
-  if (!isNumber(i)) {
-    throw new TypeError('is-odd expects a number.');
-  }
-  if (Number(i) !== Math.floor(i)) {
-    throw new RangeError('is-odd expects an integer.');
-  }
-  return !!(~~i & 1);
+  return !isEven(i);
 };

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "test": "mocha"
   },
   "dependencies": {
-    "is-number": "^4.0.0"
+    "is-even": "^1.0.0"
   },
   "devDependencies": {
     "gulp-format-md": "^1.0.0",


### PR DESCRIPTION
Given there is already an `is-odd` package, just require it and call its `isOdd` function instead of going through the messy `isNumber` shenanigans/that bitwise operation.